### PR TITLE
Issue #44 improve fitness proportionate selection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,10 @@ mod tests {
             .unwrap();
         for _ in 0..100 {
             // Parent selection
-            let mating_pool = selection::parent::stochastic_universal_sampling(
+            let mating_pool = selection::parent::fitness_proportionate_selection(
                 &mut rng,
                 &population,
                 population.individuals.len(),
-                None,
             );
 
             // Generate offspring

--- a/src/samplers.rs
+++ b/src/samplers.rs
@@ -36,7 +36,7 @@ pub fn sample_multivariate_gaussian<R: Rng + ?Sized, B: FromIterator<C>, C: From
 #[cfg(test)]
 mod tests {
     use nalgebra::{DMatrix, Dyn, Matrix, VecStorage};
-    use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
 
     use super::sample_multivariate_gaussian;
 


### PR DESCRIPTION
- Enforce effective fitnesses to always be positive non-zero values
- Change probabilities option to required value
- Separately add roulette wheel selection (weighted index sampling)